### PR TITLE
Fixed issues with multiple ECS clusters

### DIFF
--- a/lib/services/ecs_services.py
+++ b/lib/services/ecs_services.py
@@ -23,9 +23,9 @@ class Ecs_services:
             for page in page_iterator:
                 clusterArns.extend([item for item in page['clusterArns']])
             if clusterArns:
-                serviceArns = []
                 clusters = client.describe_clusters(clusters=clusterArns)
                 for cluster in clusters['clusters']:
+                    serviceArns = []
                     clusterName = cluster['clusterName']
                     paginator = client.get_paginator('list_services')
                     page_iterator = paginator.paginate(cluster=clusterName)


### PR DESCRIPTION
This was the error:

```
ERROR  us-east-1       ecsservices        An error occurred (InvalidParameterException) when calling the DescribeServices operation: Invalid identifier: Identifier is for cluster Cluster1. Your cluster is Cluster2.
```