### PR TITLE
Fixed split on loadbalancer arn

### DIFF
--- a/lib/services/alb.py
+++ b/lib/services/alb.py
@@ -36,7 +36,7 @@ class Alb:
                                         self.identifiers.append({
                                             'id': {
                                                 'TargetGroup': tg['arn'].split(':')[-1],
-                                                'LoadBalancer': lb_arn.split('loadbalancer/')[1]
+                                                'LoadBalancer': lb_arn.split(':loadbalancer/')[-1]
                                             },
                                             'tags': [{
                                                 'key': t['Key'],


### PR DESCRIPTION
Fixed bug where load balancer name would be incorrect if load balancer resource had the string "load balancer" in it. 