### PR TITLE
Add support for docdb

### DIFF
--- a/lib/services/docdb.py
+++ b/lib/services/docdb.py
@@ -1,6 +1,5 @@
 import boto3
 
-
 class Docdb:
 
     def __init__(self, region):
@@ -8,8 +7,8 @@ class Docdb:
         self.region = region
         self.identifiers = []
         self.templates = {
-            'cfn-monitor': 'DocDbInstance',
-            'cfn-guardian': 'DocDbInstance'
+            'cfn-monitor': 'DocumentDBCluster',
+            'cfn-guardian': 'DocumentDBCluster'
         }
         self.get_resources()
 

--- a/lib/services/docdb.py
+++ b/lib/services/docdb.py
@@ -1,15 +1,15 @@
 import boto3
 
 
-class Aurora:
+class Docdb:
 
     def __init__(self, region):
-        self.name = 'aurora'
+        self.name = 'docdb'
         self.region = region
         self.identifiers = []
         self.templates = {
-            'cfn-monitor': 'AuroraInstance',
-            'cfn-guardian': 'RDSClusterInstance'
+            'cfn-monitor': 'DocDbInstance',
+            'cfn-guardian': 'DocDbInstance'
         }
         self.get_resources()
 
@@ -23,7 +23,7 @@ class Aurora:
                 instances.extend([{
                     'id': item['DBInstanceIdentifier'],
                     'arn': item['DBInstanceArn'],
-                } for item in page['DBInstances'] if 'DBClusterIdentifier' in item and item['Engine'] != 'docdb'])
+                } for item in page['DBInstances'] if 'DBClusterIdentifier' in item and item['Engine'] == 'docdb'])
             for instance in instances:
                 tags = client.list_tags_for_resource(ResourceName=instance['arn'])['TagList']
                 self.identifiers.extend([{


### PR DESCRIPTION
Added support for docdb instances in monitorable, also fixed bug where docdb instances would appear under aurora & RDS cluster instance.

### Before
```yaml
====================================================================================================================================================================================================
 ap-southeast-2  aurora                 1  |
 ap-southeast-2  rds                    2  ||
====================================================================================================================================================================================================
Resources:
  RDSClusterInstance:
  - Id: docdb-2023-12-07-01-07-44
  RDSInstance:
  - Id: database-1
  - Id: database-2
```

### After
```yaml
====================================================================================================================================================================================================
ap-southeast-2  aurora                 0  
ap-southeast-2  docdb                  1  |
ap-southeast-2  rds                    2  ||
====================================================================================================================================================================================================

Resources:
  DocumentDBCluster:
  - Id: docdb-2023-12-07-01-07-44
  RDSInstance:
  - Id: database-1
  - Id: database-2
  ```